### PR TITLE
Update core.yaml

### DIFF
--- a/protocol-specifications/core/v0/api/core.yaml
+++ b/protocol-specifications/core/v0/api/core.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: DHP Core API
   description: DHP Core API specification. This is an extension of Beckn core version 0.9.3-draft, commit - d4abe91e164d032ce5dd01e2ad7c0842166e88f8
-  version: 0.7.0-draft
+  version: 0.7.0-baseline
 
 paths:
   /search:


### PR DESCRIPTION
Changed baseline version number from 0.7.0-draft to 0.7.0-baseline so that adopters do not assume it is a production version.